### PR TITLE
Optionally respond with CORS headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Oh, do you want some specific stuff? Checkout the available <a href="#options">o
 --port, --p                      change port
 --host, --h                      change the host name
 --secure, --s                    use https/wss
---cors, --c                      respond to requests with CORS headers
+--cors, --c                      respond to requests with CORS headers, use true or object to override defaults
 --quiet, --q                     no logging whatsoever
 --noBrowser, --nb                won't open the browser automagically
 --only, --o                      will only watch for changes in the given path/glob/regex/array
@@ -88,6 +88,11 @@ All the <a href="#options">options</a> being used on the `CLI` can be added to t
 {
   "port": 9999,
   "quiet": true,
+  "cors": {
+    "headers": "Content-Type, Custom-Header",
+    "methods": "GET, OPTIONS",
+    "credentials": false
+  },
   "pathIndex": "src/",
   "only": ["src/**/*"],
   "proxy": true,

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Oh, do you want some specific stuff? Checkout the available <a href="#options">o
 --port, --p                      change port
 --host, --h                      change the host name
 --secure, --s                    use https/wss
+--cors, --c                      respond to requests with CORS headers
 --quiet, --q                     no logging whatsoever
 --noBrowser, --nb                won't open the browser automagically
 --only, --o                      will only watch for changes in the given path/glob/regex/array
@@ -116,6 +117,7 @@ new Server({quiet: true}).start();
 --port          is 1307
 --host          is 127.0.0.1
 --secure        is false
+--cors          is false
 --quiet         is false
 --only          is ".", which means it'll watch everything
 --ignore        is ^(.git|node_modules|bower_components|jspm_packages|test|typings|coverage|unit_coverage)

--- a/lib/options.js
+++ b/lib/options.js
@@ -4,6 +4,7 @@ module.exports = {
   noBrowser: false,
   host: '127.0.0.1',
   secure: false,
+  cors: false,
   static: [],
   port: 1307,
   pathIndex: '',

--- a/lib/server.js
+++ b/lib/server.js
@@ -222,20 +222,26 @@ module.exports = class Server extends EventEmitter {
   }
 
   _initCors() {
-    if (this.opts.cors) {
-      this._app.use(this._cors);
+    if (!!this.opts.cors) {
+      this._app.use(this._cors());
     }
   }
 
-  _cors(req, res, next) {
-    res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
-    res.setHeader('Access-Control-Allow-Headers', 'Authorization,X-Requested-With,Content-Type');
-    res.setHeader('Access-Control-Allow-Credentials', true);
-    if (req.method === 'OPTIONS') {
-      return res.status(200).end();
+  _cors() {
+    const corsOptions = Object.assign({
+      methods: 'GET, POST, OPTIONS, PUT, PATCH, DELETE',
+      headers: 'Authorization,X-Requested-With,Content-Type',
+      credentials: true,
+    }, this.opts.cors || {});
+
+    return function(req, res, next) {
+      res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
+      res.setHeader('Access-Control-Allow-Methods', corsOptions.methods);
+      res.setHeader('Access-Control-Allow-Headers', corsOptions.headers);
+      res.setHeader('Access-Control-Allow-Credentials', corsOptions.credentials);
+
+      return req.method === 'OPTIONS' ? res.status(200).end() : next();
     }
-    return next();
   }
 
   _initProxy() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -223,17 +223,19 @@ module.exports = class Server extends EventEmitter {
 
   _initCors() {
     if (this.opts.cors) {
-      this._app.use(function(req, res, next) {
-        res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
-        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
-        res.setHeader('Access-Control-Allow-Headers', 'Authorization,X-Requested-With,Content-Type');
-        res.setHeader('Access-Control-Allow-Credentials', true);
-        if (req.method === 'OPTIONS') {
-          return res.status(200).end();
-        }
-        return next();
-      });
+      this._app.use(this._cors);
     }
+  }
+
+  _cors(req, res, next) {
+    res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
+    res.setHeader('Access-Control-Allow-Headers', 'Authorization,X-Requested-With,Content-Type');
+    res.setHeader('Access-Control-Allow-Credentials', true);
+    if (req.method === 'OPTIONS') {
+      return res.status(200).end();
+    }
+    return next();
   }
 
   _initProxy() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -132,6 +132,10 @@ module.exports = class Server extends EventEmitter {
       {
         short: 'st',
         long: 'static'
+      },
+      {
+        short: 'c',
+        long: 'cors'
       }
     ];
 
@@ -204,6 +208,8 @@ module.exports = class Server extends EventEmitter {
       threshold: '1kb'
     }));
 
+    this._initCors();
+
     this.opts.static.forEach((p) => {
       this._app.use(express.static(p, {
         index: false
@@ -215,22 +221,37 @@ module.exports = class Server extends EventEmitter {
     this._app.get(/.+/, (req, res) => this._sendIndex(req, res));
   }
 
+  _initCors() {
+    if (this.opts.cors) {
+      this._app.use(function(req, res, next) {
+        res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
+        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
+        res.setHeader('Access-Control-Allow-Headers', 'Authorization,X-Requested-With,Content-Type');
+        res.setHeader('Access-Control-Allow-Credentials', true);
+        if (req.method === 'OPTIONS') {
+          return res.status(200).end();
+        }
+        return next();
+      });
+    }
+  }
+
   _initProxy() {
     if (this.opts.proxy) {
       this._app.all(this.opts.proxyWhen, (req, res) => {
         this.emit('proxy', {req: req});
         this._proxyServer.web(req, res);
-      })
+      });
 
       this._proxyServer.on('proxyReq', (proxyReq, req) => {
         req._proxyReq = proxyReq;
-  	  })
+      });
 
-  	  this._proxyServer.on('error', (err, req, res) => {
+      this._proxyServer.on('error', (err, req, res) => {
         if (req.socket.destroyed && err.code === 'ECONNRESET') {
           req._proxyReq.abort();
         }
-      })
+      });
     }
   }
 

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -10,6 +10,7 @@ describe('options', () => {
     expect(options.pathIndex).to.equal('');
     expect(options.noBrowser).to.be.false;
     expect(options.secure).to.be.false;
+    expect(options.cors).to.be.false;
     expect(options.static).to.deep.equal([]);
     expect(options.quiet).to.be.false;
     expect(options.proxy).to.be.false;

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -43,6 +43,7 @@ describe('server', () => {
       expect(_server.opts.host).to.equal('127.0.0.1');
       expect(_server.opts.port).to.equal(1307);
       expect(_server.opts.secure).to.equal(false);
+      expect(_server.opts.cors).to.be.false;
       expect(_server.opts.quiet).to.be.false;
       expect(_server.opts.pathIndex).to.equal('');
       expect(_server.opts.noBrowser).to.equal(false);

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -561,14 +561,21 @@ describe('server', () => {
   });
 
   describe('options', function() {
-    it('should open the browser and use CORS', () => {
+    it('should open the browser and use CORS', (done) => {
       let _server = new Server({
         cors: true,
+        quiet: true,
+        pathIndex: 'test/'
       });
 
       let _openStub = sinon.stub(_server, '_open', () => {});
 
       _server.start();
+
+      http.get(`http://${_server.opts.host}:${_server.opts.port}/`, function(res) {
+        expect(res.headers['access-control-allow-origin']).to.not.be.undefined;
+        return done();
+      })
 
       expect(_server._open).to.have.been.called;
       expect(_server._cors).to.have.been.called;

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -561,9 +561,11 @@ describe('server', () => {
   });
 
   describe('options', function() {
-    it('should open the browser and use CORS', (done) => {
+    it('should open the browser and use CORS with custom access-control-allow-headers', (done) => {
       let _server = new Server({
-        cors: true,
+        cors: {
+          headers: 'test-header',
+        },
         quiet: true,
         pathIndex: 'test/'
       });
@@ -574,6 +576,8 @@ describe('server', () => {
 
       http.get(`http://${_server.opts.host}:${_server.opts.port}/`, function(res) {
         expect(res.headers['access-control-allow-origin']).to.not.be.undefined;
+        expect(res.headers['access-control-allow-headers']).to.equal('test-header');
+        expect(res.headers['access-control-allow-credentials']).to.equal('true');
         return done();
       })
 

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -561,16 +561,21 @@ describe('server', () => {
   });
 
   describe('options', function() {
-    it('should open the browser', () => {
-      let _server = new Server();
+    it('should open the browser and use CORS', () => {
+      let _server = new Server({
+        cors: true,
+      });
 
       let _openStub = sinon.stub(_server, '_open', () => {});
+      let _corsStub = sinon.stub(_server, '_cors', () => {});
 
       _server.start();
 
       expect(_server._open).to.have.been.called;
+      expect(_server._cors).to.have.been.called;
 
       _openStub.restore();
+      _corsStub.restore();
     });
   });
 

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -567,7 +567,6 @@ describe('server', () => {
       });
 
       let _openStub = sinon.stub(_server, '_open', () => {});
-      let _corsStub = sinon.stub(_server, '_cors', () => {});
 
       _server.start();
 
@@ -575,7 +574,6 @@ describe('server', () => {
       expect(_server._cors).to.have.been.called;
 
       _openStub.restore();
-      _corsStub.restore();
     });
   });
 


### PR DESCRIPTION
I am developing an application that runs on dynamic hostnames and needed to respond with CORS headers for static content. The new method adds headers to the response that allow the content to be loaded in the browser.